### PR TITLE
Remove #include "config.h" since we use cmake

### DIFF
--- a/src/common/private.h
+++ b/src/common/private.h
@@ -20,7 +20,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
-#include "config.h"
 #include "tree.h"
 
 /* Maximum events returnable in a single kevent() call */


### PR DESCRIPTION
This include triggers an error on Windows and is useless with CMake.