### PR TITLE
Fix endianness issue when calling ioctl on Linux

### DIFF
--- a/src/linux/read.c
+++ b/src/linux/read.c
@@ -124,11 +124,13 @@ evfilt_read_copyout(struct kevent *dst, struct knote *src, void *ptr)
         /* On return, data contains the number of bytes of protocol
            data available to read.
          */
-        if (ioctl(dst->ident, SIOCINQ, &dst->data) < 0) {
+        int i;
+        if (ioctl(dst->ident, SIOCINQ, &i) < 0) {
             /* race condition with socket close, so ignore this error */
             dbg_puts("ioctl(2) of socket failed");
             dst->data = 0;
         } else {
+            dst->data = i;
             if (dst->data == 0)
                 dst->flags |= EV_EOF;
         }


### PR DESCRIPTION
`ioctl` expects an `int `pointer but was given a `long `pointer.  It works on little-endian Linux.
This is incorrect on big-endian Linux and the socket tests (test/read.c) failed.