### PR TITLE
[RFC] Timer: Set EPOLLONESHOT for EPOLL_CTL_ADD after knote creation

### DIFF
--- a/src/linux/timer.c
+++ b/src/linux/timer.c
@@ -151,7 +151,10 @@ evfilt_timer_knote_create(struct filter *filt, struct knote *kn)
     }
 
     memset(&ev, 0, sizeof(ev));
-    ev.events = EPOLLIN;
+    ev.events = EPOLLIN | EPOLLET;
+    if (kn->kev.flags & (EV_ONESHOT | EV_DISPATCH))
+        ev.events |= EPOLLONESHOT;
+
     ev.data.ptr = kn;
     if (epoll_ctl(filter_epfd(filt), EPOLL_CTL_ADD, tfd, &ev) < 0) {
         dbg_printf("epoll_ctl(2): %d", errno);


### PR DESCRIPTION
When using libkqueue, I see `knote.c:153: knote_disable: Assertion '!(kn->kev.flags & 0x0008)' failed.` (EV_DISABLE set twice on the same knote).

This patch ensures that `EPOLLONESHOT` is set on the ev.events if we are processing an `EV_ONESHOT` or `EV_DISPATCH` timer kevent.  There is similar logic already in linux/write.c and linux/read.c

The patch resolves the assertion I am seeing.  Comments very welcome as I am new to libkqueue.  Thank you.