### PR TITLE
Add configure arg to disable install and build noinst ltlibrary

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,15 @@
 
 # FIXME - Only supports Linux for now
 
-lib_LTLIBRARIES = libkqueue.la
 kqincludedir = $(includedir)/kqueue/sys
-kqinclude_HEADERS = include/sys/event.h
-dist_man_MANS = kqueue.2
+
+if INSTALL
+    lib_LTLIBRARIES = libkqueue.la
+    kqinclude_HEADERS = include/sys/event.h
+    dist_man_MANS = kqueue.2
+else
+    noinst_LTLIBRARIES = libkqueue.la
+endif
 
 libkqueue_la_CFLAGS = -I./src/common -I./include -Wall -Wextra -Wno-missing-field-initializers -Werror -g -O2 -std=c99 -D_XOPEN_SOURCE=600 -fvisibility=hidden
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,13 @@ AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
 
+# When building as submodule allow selection of noinst targets
+AC_ARG_ENABLE([libkqueue-install],
+  [AS_HELP_STRING([--disable-libkqueue-install],
+    [Disable install rules and build noinst libtool library])],,
+  [enable_libkqueue_install=yes]
+)
+AM_CONDITIONAL([INSTALL],[test "x$enable_libkqueue_install" != "xno"])
 
 AC_CHECK_HEADER([sys/event.h])
 AC_CHECK_DECL([EPOLLRDHUP], [], [], [[#include <sys/epoll.h>]])


### PR DESCRIPTION
This commit adds a --disable-libkqueue-install to configure.ac which allows the user to specify that libkqueue should be built as a noinst library.

A noinst library is needed when building and linking libkqueue statically into another library.