### PR TITLE
Allow tests to be built from separate build directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ kqtest_SOURCES = \
        test/user.c \
        test/common.h
 
-kqtest_CFLAGS = -g -O0 -Wall -Werror -I$(top_srcdir)/include -I$(top_srcdir)/test
+kqtest_CFLAGS = -g -O0 -Wall -Werror -I$(top_srcdir)/include -I$(top_srcdir)/test -I$(builddir)
 
 kqtest_LDADD = -lpthread -lrt libkqueue.la
 

--- a/test/common.h
+++ b/test/common.h
@@ -48,11 +48,11 @@
 #include <arpa/inet.h>
 #include <pthread.h>
 #include <poll.h>
-#include "../config.h"
+#include "config.h"
 #include <netdb.h>
 #else
-# include "../include/sys/event.h"
-# include "../src/windows/platform.h"
+# include "include/sys/event.h"
+# include "src/windows/platform.h"
 #endif
 
 struct test_context;

--- a/test/lockstat.c
+++ b/test/lockstat.c
@@ -16,7 +16,7 @@
 
 #include <err.h>
 #include <pthread.h>
-#include "../src/common/private.h"
+#include "src/common/private.h"
 
 int DEBUG_KQUEUE = 1;
 char * KQUEUE_DEBUG_IDENT = "lockstat";

--- a/test/stress/main.c
+++ b/test/stress/main.c
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "../config.h"
+#include "config.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
When building the tests from an alternative build directory (i.e. where libkqueue is being used as a submodule of libdispatch in the Swift build process), the following error occurs:
```
/home/buildnode/jenkins/workspace/oss-swift-incremental-RA-libdispatch-linux-ubuntu-15_10/swift-corelibs-libdispatch/libkqueue/test/common.h:51:23: fatal error: ../config.h: No such file or directory
compilation terminated.
```
Removing the use of relative paths and adding `-I$(builddir)` to the `kqtest_CFLAGS` resolves this.

I've confirmed that the changes work when building in both local and remote directories.