### PR TITLE
support for kevent64 type timer resolutions

### DIFF
--- a/include/sys/event.h
+++ b/include/sys/event.h
@@ -168,6 +168,15 @@ struct kevent {
                                    program */
 #define VQ_NOTRESPLOCK  0x0080  /* server lockd down */
 
+/*
+ * data/hint flags for EVFILT_TIMER as suported and defined in kevent64
+ */
+#define NOTE_SECONDS    0x0001  /* time specified in seconds */
+#define NOTE_USECONDS   0x0002  /* time specified in micro seconds */
+#define NOTE_NSECONDS   0x0004  /* time specified in nano seconds */
+#define NOTE_ABSOLUTE   0x0008  /* data is an absolute timeout */
+
+
 
 #ifndef __KERNEL__
 #ifdef  __cplusplus

--- a/kqueue.2
+++ b/kqueue.2
@@ -364,7 +364,21 @@ Establishes an arbitrary timer identified by
 .Va ident .
 When adding a timer,
 .Va data
-specifies the timeout period in milliseconds.
+specifies the timeout period and
+.Va fflags
+can be set to one of the following:
+.Bl -tag -width XXNOTE_RENAME
+.It NOTE_SECONDS
+data is in seconds
+.It NOTE_USECONDS
+data is in microseconds
+.It NOTE_NSECONDS
+data is in nanoseconds
+.It NOTE_ABSOLUTE
+data is an absolute timeout
+.El
+.Pp
+If fflags is not set, the default is milliseconds.
 The timer will be periodic unless EV_ONESHOT is specified.
 On return,
 .Va data


### PR DESCRIPTION
libdispatch requires nanosecond resolutions, which currently are not available in the kevent API.
kevent64 provides these including many other extensions.
The following patch provides the required additions to the kevent API by defining the four NOTE_ flags and implementing them in src/linux/timer.c 
Patch has been verified with the linux libdispatch that sets those flags.