### PR TITLE
Add option to provide Bionic Libc (Android) support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,9 @@ libkqueue_la_SOURCES = \
        src/common/tree.h \
        src/linux/platform.h
 
+if !BIONIC_LIBC
 libkqueue_la_LIBADD = -lpthread -lrt
+endif
 
 pkgconfigdir=$(libdir)/pkgconfig
 pkgconfig_DATA=libkqueue.pc
@@ -58,6 +60,10 @@ kqtest_SOURCES = \
 
 kqtest_CFLAGS = -g -O0 -Wall -Werror -I$(top_srcdir)/include -I$(top_srcdir)/test -I$(builddir)
 
+if BIONIC_LIBC
+kqtest_LDADD = -lpthread
+else
 kqtest_LDADD = -lpthread -lrt libkqueue.la
+endif
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,14 @@ AC_ARG_ENABLE([libkqueue-install],
 )
 AM_CONDITIONAL([INSTALL],[test "x$enable_libkqueue_install" != "xno"])
 
+# Add option to provide Bionic Libc (Android) support
+AC_ARG_ENABLE([bionic-libc],
+  [AS_HELP_STRING([--enable-bionic-libc],
+    [Build for Bionic Libc (Android)])],,
+  [enable_bionic_libc=yes]
+)
+AM_CONDITIONAL(BIONIC_LIBC, [test "x$enable_bionic_libc" == "xyes"])
+
 AC_CHECK_HEADER([sys/event.h])
 AC_CHECK_DECL([EPOLLRDHUP], [], [], [[#include <sys/epoll.h>]])
 AC_CHECK_DECL([ppoll], [], [], [[


### PR DESCRIPTION
This changeset adds an option to `configure.ac` named `--enable-bionic-libc` to provide compatibility with [Bionic Libc](https://github.com/android/platform_bionic), mainly used in Android.

Bionic embeds `libpthread` and `librt`, so there's nothing extra to link, causing this to fail due to file inexistence: `-lpthread -lrt`. 

This change will allow [apple/swift-corelibs-libdispatch](https://github.com/apple/swift-corelibs-libdispatch) to be compiled with Android support along with the changes in [apple/swift-corelibs-libdispatch#162](https://github.com/apple/swift-corelibs-libdispatch/pull/162).

Let me know if you prefer to solve this in some other way, or if there's any change that needs to be applied.