### PR TITLE
fix linux build break introduced by bionic-libc change

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AM_CONDITIONAL([INSTALL],[test "x$enable_libkqueue_install" != "xno"])
 AC_ARG_ENABLE([bionic-libc],
   [AS_HELP_STRING([--enable-bionic-libc],
     [Build for Bionic Libc (Android)])],,
-  [enable_bionic_libc=yes]
+  [enable_bionic_libc=no]
 )
 AM_CONDITIONAL(BIONIC_LIBC, [test "x$enable_bionic_libc" == "xyes"])
 


### PR DESCRIPTION
Fixes build break on Linux introduced by d90d1ab.
If no explicit command line argument is given,
enable_bionic_libc should default to no.