### PR TITLE
Fixed timespec redefinition in Visual Studio 2015

### DIFF
--- a/include/sys/event.h
+++ b/include/sys/event.h
@@ -185,10 +185,14 @@ extern "C" {
 
 #ifdef _WIN32
 
+#if (_MSC_VER < 1900)
 struct timespec {
     time_t  tv_sec;
     long    tv_nsec;
 };
+#else
+#include <time.h>
+#endif
 
 __declspec(dllexport) int
 kqueue(void);


### PR DESCRIPTION
Starting at Visual Studio 2015, the timespec structure is defined in time.h. If applications include both time.h and sys/event.h, a structure redefinition error will occur.

This fix includes time.h when the compiler is VS2015 or higher and uses the own definition of timespec for lower versions of the compiler.