### PR TITLE
Build system rewrite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,33 +19,33 @@ INCLUDE (CheckIncludeFiles)
 
 project(kqueue)
 
-#files
+# files
 file(GLOB_RECURSE INCL include/*.h)
 source_group(includes FILES ${INCL})
 
 if(WIN32)
-	file(GLOB SRC 
+	file(GLOB SRC
 		src/windows/*.h
 		src/windows/*.c
-        src/common/*.h
+		src/common/*.h
 		src/*.c
-        src/common/map.c
-        src/common/filter.c
-        src/common/knote.c
-        src/common/kevent.c
-        src/common/kqueue.c
+		src/common/map.c
+		src/common/filter.c
+		src/common/knote.c
+		src/common/kevent.c
+		src/common/kqueue.c
 	)
 	add_definitions(
 		-DLIBKQUEUE_EXPORTS
 		-D_USRDLL
 		-D_WINDLL
 	)
-    if(MINGW)
-        SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}  -march=i486")
-        SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -march=i486")
-    endif()
+	if(MINGW)
+		SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}  -march=i486")
+		SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -march=i486")
+	endif()
 else()
-	file(GLOB SRC 
+	file(GLOB SRC
 		src/posix/*.h
 		src/posix/platform.c
 		src/linux/*.h
@@ -62,7 +62,7 @@ else()
 		src/common/knote.c
 		src/common/map.c
 		src/common/kevent.c
-		src/common/kqueue.c		
+		src/common/kqueue.c
 	)
 	include_directories(
 		src/common
@@ -86,9 +86,9 @@ include_directories(
 option(STATIC_KQUEUE "Enable to build libkqueue as static lib" OFF)
 if(STATIC_KQUEUE)
 	message("-- building libkqueue as static lib")
-    add_library(kqueue STATIC ${SRC} ${INCL})
+	add_library(kqueue STATIC ${SRC} ${INCL})
 else()
-    add_library(kqueue SHARED ${SRC} ${INCL})
+	add_library(kqueue SHARED ${SRC} ${INCL})
 endif()
 
 if(WIN32)
@@ -103,6 +103,6 @@ set_target_properties(kqueue PROPERTIES DEBUG_POSTFIX "D")
 #tests
 option(KQUEUE_TESTS "Enable to build tests for libkqueue" OFF)
 if(KQUEUE_TESTS)
-    message("-- Adding tests for libkqueue")
-    add_subdirectory(test)
+	message("-- Adding tests for libkqueue")
+	add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,95 +14,135 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-cmake_minimum_required(VERSION 2.8)
-INCLUDE (CheckIncludeFiles)
+cmake_minimum_required(VERSION 2.8.4)
+cmake_policy(SET CMP0063 OLD)
 
-project(kqueue)
+project(kqueue C)
 
-# files
-file(GLOB_RECURSE INCL include/*.h)
-source_group(includes FILES ${INCL})
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 99)
 
-if(WIN32)
-	file(GLOB SRC
-		src/windows/*.h
-		src/windows/*.c
-		src/common/*.h
-		src/*.c
-		src/common/map.c
-		src/common/filter.c
-		src/common/knote.c
-		src/common/kevent.c
-		src/common/kqueue.c
-	)
-	add_definitions(
-		-DLIBKQUEUE_EXPORTS
-		-D_USRDLL
-		-D_WINDLL
-	)
-	if(MINGW)
-		SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}  -march=i486")
-		SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -march=i486")
-	endif()
-else()
-	file(GLOB SRC
-		src/posix/*.h
-		src/posix/platform.c
-		src/linux/*.h
-		src/linux/platform.c
-		src/linux/signal.c
-		src/linux/socket.c
-		src/linux/timer.c
-		src/linux/user.c
-		src/linux/vnode.c
-		src/linux/write.c
-		src/linux/read.c
-		src/common/*.h
-		src/common/filter.c
-		src/common/knote.c
-		src/common/map.c
-		src/common/kevent.c
-		src/common/kqueue.c
-	)
-	include_directories(
-		src/common
-	)
-	add_definitions(
-		-Wall -Werror
-		-fpic
-		-D_XOPEN_SOURCE=600
-		-std=c99
-		-fvisibility=hidden
-	)
+option(STATIC_KQUEUE "build libkqueue as static library" OFF)
+option(ENABLE_TESTS "build tests for libkqueue" OFF)
+
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREADS_FLAG TRUE)
+find_package(Threads REQUIRED)
+
+include(CheckIncludeFiles)
+include(CheckSymbolExists)
+
+check_include_files(sys/signalfd.h HAVE_SYS_SIGNALFD_H)
+check_include_files(sys/timerfd.h HAVE_SYS_TIMERFD_H)
+check_include_files(sys/eventfd.h HAVE_SYS_EVENTFD_H)
+if(ENABLE_TESTS)
+  check_include_files(err.h HAVE_ERR_H)
 endif()
-source_group(src FILES ${SRC})
 
-#includes
-include_directories(
-	include
-)
+check_symbol_exists(EPOLLRDHUP sys/epoll.h HAVE_EPOLLRDHUP)
+check_symbol_exists(NOTE_TRUNCATE sys/event.h HAVE_NOTE_TRUNCATE)
+if(ENABLE_TESTS)
+  check_symbol_exists(NOTE_REVOKE sys/event.h HAVE_NOTE_REVOKE)
+endif()
 
-#library (static or shared)
-option(STATIC_KQUEUE "Enable to build libkqueue as static lib" OFF)
+set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+check_symbol_exists(ppoll poll.h HAVE_DECL_PPOLL)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+set(LIBKQUEUE_HEADERS
+    include/sys/event.h)
+
+set(LIBKQUEUE_SOURCES
+    src/common/alloc.h
+    src/common/debug.h
+    src/common/filter.c
+    src/common/kevent.c
+    src/common/knote.c
+    src/common/kqueue.c
+    src/common/map.c
+    src/common/private.h
+    src/common/queue.h
+    src/common/tree.h)
+
+if(CMAKE_SYSTEM_NAME MATCHES Windows)
+  list(APPEND LIBKQUEUE_SOURCES
+       src/windows/platform.c
+       src/windows/platform.h
+       src/windows/read.c
+       src/windows/stdint.h
+       src/windows/timer.c
+       src/windows/user.c)
+elseif(CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)")
+  list(APPEND LIBKQUEUE_SOURCES
+       src/posix/platform.c
+       src/posix/platform.h
+       src/solaris/platform.c
+       src/solaris/platform.h
+       src/solaris/signal.c
+       src/solaris/socket.c
+       src/solaris/timer.c
+       src/solaris/user.c)
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  list(APPEND LIBKQUEUE_SOURCES
+       src/posix/platform.c
+       src/posix/platform.h
+       src/linux/platform.c
+       src/linux/platform.h
+       src/linux/read.c
+       src/linux/signal.c
+       src/linux/timer.c
+       src/linux/user.c
+       src/linux/vnode.c
+       src/linux/write.c)
+else()
+  message(FATAL_ERROR "unsupported host os")
+endif()
+
+source_group(includes
+             FILES
+               ${LIBKQUEUE_HEADERS})
+source_group(src
+             FILES
+               ${LIBKQUEUE_SOURCES})
+
 if(STATIC_KQUEUE)
-	message("-- building libkqueue as static lib")
-	add_library(kqueue STATIC ${SRC} ${INCL})
+  set(LIBRARY_TYPE STATIC)
 else()
-	add_library(kqueue SHARED ${SRC} ${INCL})
+  set(LIBRARY_TYPE SHARED)
 endif()
 
-if(WIN32)
-	set(LIB ${LIB} Ws2_32)
-endif()
-if(NOT WIN32)
-	set(LIB ${LIB} pthread)
-endif()
-target_link_libraries(kqueue ${LIB})
+add_library(kqueue ${LIBRARY_TYPE} ${LIBKQUEUE_SOURCES} ${LIBKQUEUE_HEADERS})
 set_target_properties(kqueue PROPERTIES DEBUG_POSTFIX "D")
 
-#tests
-option(KQUEUE_TESTS "Enable to build tests for libkqueue" OFF)
-if(KQUEUE_TESTS)
-	message("-- Adding tests for libkqueue")
-	add_subdirectory(test)
+if(WIN32)
+  target_compile_definitions(kqueue PRIVATE LIBKQUEUE_EXPORTS;_USRDLL;_WINDLL)
+else()
+  target_compile_definitions(kqueue PRIVATE _XOPEN_SOURCE=600)
 endif()
+
+target_include_directories(kqueue PRIVATE include)
+if(NOT WIN32)
+  target_include_directories(kqueue PRIVATE src/common)
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES GNU)
+  target_compile_options(kqueue PRIVATE -Wall -Werror)
+endif()
+if(MINGW AND CMAKE_C_COMPILER_ID MATCHES GNU)
+  target_compile_options(kqueue PRIVATE -march=i486)
+endif()
+
+if(WIN32)
+  target_link_libraries(kqueue PRIVATE Ws2_32)
+endif()
+target_link_libraries(kqueue PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+
+if(ENABLE_TESTS)
+  add_subdirectory(test)
+endif()
+

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,11 @@
+
+#cmakedefine01 HAVE_SYS_SIGNALFD_H
+#cmakedefine01 HAVE_SYS_TIMERFD_H
+#cmakedefine01 HAVE_SYS_EVENTFD_H
+#cmakedefine01 HAVE_ERR_H
+
+#cmakedefine01 HAVE_EPOLLRDHUP
+#cmakedefine01 HAVE_NOTE_TRUNCATE
+#cmakedefine01 HAVE_DECL_PPOLL
+#cmakedefine01 HAVE_NOTE_REVOKE
+


### PR DESCRIPTION
Update the cmake build system to use modern recommendations.  Take the opportunity to port the remainder of the checks from autotools into the CMake based system even when building for Linux.  This support is sufficient to cross-compile libkqueue from Linux to Windows (via clang-cl, lld, and the Windows SDK on a case-insensitive file system) as well as to build for Linux.

The cmake based build on Linux has been tested and passes all tests.