### PR TITLE
windows: clear up some warnings from clang on Windows

### DIFF
--- a/src/windows/platform.h
+++ b/src/windows/platform.h
@@ -46,8 +46,8 @@
 /*
  * Atomic integer operations 
  */
-#define atomic_inc   InterlockedIncrement
-#define atomic_dec   InterlockedDecrement
+#define atomic_inc(value) InterlockedIncrement((LONG volatile *)value)
+#define atomic_dec(value) InterlockedDecrement((LONG volatile *)value)
 #define atomic_cas(p, oval, nval) InterlockedCompareExchange(p, nval, oval)
 #define atomic_ptr_cas(p, oval, nval) InterlockedCompareExchangePointer(p, nval, oval)
 


### PR DESCRIPTION
Address some -Wincompatible-pointer-types-discards-qualifier and
-Wincompatible-pointer-types warnings from clang.  Since the atomic operands are
often int types and the _Interlocked{In,De}crement functions on Windows expect a
`LONG volatile *`, clang emits a warning.  Silence the warning with an explicit
cast to the type.

Identified by clang-cl 3.9.0 on Visual Studio 14.