### PR TITLE
build: clean up warnings on test for Windows

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,5 +56,17 @@ else()
 endif()
 
 add_executable(libkqueue-test ${SRC})
+target_include_directories(libkqueue-test PRIVATE ${CMAKE_SOURCE_DIR})
+if(WIN32)
+  target_compile_definitions(libkqueue-test
+                             PRIVATE
+                               _CRT_SECURE_NO_WARNINGS
+                               _CRT_NONSTDC_NO_WARNINGS
+                               _WINSOCK_DEPRECATED_NO_WARNINGS)
+  if(CMAKE_C_COMPILER_ID MATCHES Clang)
+    target_compile_options(libkqueue-test PRIVATE -Wno-unused-variable)
+  endif()
+endif()
 target_link_libraries(libkqueue-test kqueue ${LIBS})
 set_target_properties(libkqueue-test PROPERTIES DEBUG_POSTFIX "D")
+


### PR DESCRIPTION
When building the tests for Windows with clang-cl 3.9 on Visual Studio 14, the
output was completely cluttered with deprecation warnings for a number of APIs
that the test uses.  Furthermore, the tests have a number of unused variables.
Silence the warnings.