### PR TITLE
Fix inotify events with names

### DIFF
--- a/src/linux/vnode.c
+++ b/src/linux/vnode.c
@@ -49,9 +49,15 @@ inotify_event_dump(struct inotify_event *evt)
 {
     static __thread char buf[1024];
 
-    snprintf(buf, sizeof(buf), "wd=%d mask=%s",
-            evt->wd,
-            inotify_mask_dump(evt->mask));
+    if (evt->len > 0)
+        snprintf(buf, sizeof(buf), "wd=%d mask=%s name=%s",
+                evt->wd,
+                inotify_mask_dump(evt->mask),
+                evt->name);
+    else
+        snprintf(buf, sizeof(buf), "wd=%d mask=%s",
+                evt->wd,
+                inotify_mask_dump(evt->mask));
 
     return (buf);
 }
@@ -59,30 +65,37 @@ inotify_event_dump(struct inotify_event *evt)
 #endif /* !NDEBUG */
 
 
-/* TODO: USE this to get events with name field */
 int
-get_one_event(struct inotify_event *dst, int inofd)
+get_one_event(struct inotify_event *dst, size_t len, int inofd)
 {
     ssize_t n;
+    size_t want = sizeof(struct inotify_event);
 
     dbg_puts("reading one inotify event");
     for (;;) {
-        n = read(inofd, dst, sizeof(*dst));
+        if (len < want) {
+            dbg_printf("Needed %zu bytes have %zu bytes", want, len);
+            return (-1);
+        }
+
+        n = read(inofd, dst, want);
         if (n < 0) {
-            if (errno == EINTR)
+            switch (errno) {
+            case EINVAL:
+                want += sizeof(struct inotify_event);
+                /* FALL-THROUGH */
+
+            case EINTR:
                 continue;
+            }
+
             dbg_perror("read");
             return (-1);
-        } else {
-            break;
         }
+        break;
     }
-    dbg_printf("read(2) from inotify wd: %ld bytes", (long) n);
 
-    /* FIXME-TODO: if len > 0, read(len) */
-    if (dst->len != 0)
-        abort();
-
+    dbg_printf("read(2) from inotify wd: %ld bytes", (long)n);
 
     return (0);
 }
@@ -170,14 +183,16 @@ delete_watch(struct filter *filt, struct knote *kn)
 int
 evfilt_vnode_copyout(struct kevent *dst, struct knote *src, void *ptr UNUSED)
 {
-    struct inotify_event evt;
+    uint8_t buf[sizeof(struct inotify_event) + NAME_MAX + 1] __attribute__ ((aligned(__alignof__(struct inotify_event))));
+    struct inotify_event *evt;
     struct stat sb;
 
-    if (get_one_event(&evt, src->kdata.kn_inotifyfd) < 0)
+    evt = (struct inotify_event *)buf;
+    if (get_one_event(evt, sizeof(buf), src->kdata.kn_inotifyfd) < 0)
         return (-1);
 
-    dbg_printf("inotify event: %s", inotify_event_dump(&evt));
-    if (evt.mask & IN_IGNORED) {
+    dbg_printf("inotify event: %s", inotify_event_dump(evt));
+    if (evt->mask & IN_IGNORED) {
         /* TODO: possibly return error when fs is unmounted */
         dst->filter = 0;
         return (0);
@@ -187,7 +202,7 @@ evfilt_vnode_copyout(struct kevent *dst, struct knote *src, void *ptr UNUSED)
        XXX-this may not exactly match the kevent() behavior if multiple file de
 scriptors reference the same file.
     */
-    if (evt.mask & IN_CLOSE_WRITE || evt.mask & IN_CLOSE_NOWRITE) {
+    if (evt->mask & IN_CLOSE_WRITE || evt->mask & IN_CLOSE_NOWRITE) {
         src->kn_flags |= EV_ONESHOT; /* KLUDGE: causes the knote to be deleted */
         dst->filter = 0; /* KLUDGE: causes the event to be discarded */
         return (0);
@@ -198,7 +213,7 @@ scriptors reference the same file.
 
     /* No error checking because fstat(2) should rarely fail */
     //FIXME: EINTR
-    if ((evt.mask & IN_ATTRIB || evt.mask & IN_MODIFY)
+    if ((evt->mask & IN_ATTRIB || evt->mask & IN_MODIFY)
         && fstat(src->kev.ident, &sb) == 0) {
         if (sb.st_nlink == 0 && src->kev.fflags & NOTE_DELETE)
             dst->fflags |= NOTE_DELETE;
@@ -214,22 +229,22 @@ scriptors reference the same file.
        src->data.vnode.size = sb.st_size;
     }
 
-    if (evt.mask & IN_MODIFY && src->kev.fflags & NOTE_WRITE)
+    if (evt->mask & IN_MODIFY && src->kev.fflags & NOTE_WRITE)
         dst->fflags |= NOTE_WRITE;
-    if (evt.mask & IN_ATTRIB && src->kev.fflags & NOTE_ATTRIB)
+    if (evt->mask & IN_ATTRIB && src->kev.fflags & NOTE_ATTRIB)
         dst->fflags |= NOTE_ATTRIB;
-    if (evt.mask & IN_MOVE_SELF && src->kev.fflags & NOTE_RENAME)
+    if (evt->mask & IN_MOVE_SELF && src->kev.fflags & NOTE_RENAME)
         dst->fflags |= NOTE_RENAME;
-    if (evt.mask & IN_DELETE_SELF && src->kev.fflags & NOTE_DELETE)
+    if (evt->mask & IN_DELETE_SELF && src->kev.fflags & NOTE_DELETE)
         dst->fflags |= NOTE_DELETE;
 
-    if (evt.mask & IN_MODIFY && src->kev.fflags & NOTE_WRITE)
+    if (evt->mask & IN_MODIFY && src->kev.fflags & NOTE_WRITE)
         dst->fflags |= NOTE_WRITE;
-    if (evt.mask & IN_ATTRIB && src->kev.fflags & NOTE_ATTRIB)
+    if (evt->mask & IN_ATTRIB && src->kev.fflags & NOTE_ATTRIB)
         dst->fflags |= NOTE_ATTRIB;
-    if (evt.mask & IN_MOVE_SELF && src->kev.fflags & NOTE_RENAME)
+    if (evt->mask & IN_MOVE_SELF && src->kev.fflags & NOTE_RENAME)
         dst->fflags |= NOTE_RENAME;
-    if (evt.mask & IN_DELETE_SELF && src->kev.fflags & NOTE_DELETE)
+    if (evt->mask & IN_DELETE_SELF && src->kev.fflags & NOTE_DELETE)
         dst->fflags |= NOTE_DELETE;
 
     return (0);

--- a/src/linux/vnode.c
+++ b/src/linux/vnode.c
@@ -49,7 +49,7 @@ inotify_event_dump(struct inotify_event *evt)
 {
     static __thread char buf[1024];
 
-    snprintf(buf, sizeof(buf), "wd=%d mask=%s", 
+    snprintf(buf, sizeof(buf), "wd=%d mask=%s",
             evt->wd,
             inotify_mask_dump(evt->mask));
 
@@ -80,7 +80,7 @@ get_one_event(struct inotify_event *dst, int inofd)
     dbg_printf("read(2) from inotify wd: %ld bytes", (long) n);
 
     /* FIXME-TODO: if len > 0, read(len) */
-    if (dst->len != 0) 
+    if (dst->len != 0)
         abort();
 
 
@@ -103,11 +103,11 @@ add_watch(struct filter *filt, struct knote *kn)
     mask = IN_CLOSE;
     if (kn->kev.fflags & NOTE_DELETE)
         mask |= IN_ATTRIB | IN_DELETE_SELF;
-    if (kn->kev.fflags & NOTE_WRITE)      
+    if (kn->kev.fflags & NOTE_WRITE)
         mask |= IN_MODIFY | IN_ATTRIB;
     if (kn->kev.fflags & NOTE_EXTEND)
         mask |= IN_MODIFY | IN_ATTRIB;
-    if ((kn->kev.fflags & NOTE_ATTRIB) || 
+    if ((kn->kev.fflags & NOTE_ATTRIB) ||
             (kn->kev.fflags & NOTE_LINK))
         mask |= IN_ATTRIB;
     if (kn->kev.fflags & NOTE_RENAME)
@@ -123,7 +123,7 @@ add_watch(struct filter *filt, struct knote *kn)
     }
 
     /* Add the watch */
-    dbg_printf("inotify_add_watch(2); inofd=%d, %s, path=%s", 
+    dbg_printf("inotify_add_watch(2); inofd=%d, %s, path=%s",
             ifd, inotify_mask_dump(mask), path);
     kn->kev.data = inotify_add_watch(ifd, path, mask);
     if (kn->kev.data < 0) {
@@ -183,7 +183,7 @@ evfilt_vnode_copyout(struct kevent *dst, struct knote *src, void *ptr UNUSED)
         return (0);
     }
 
-    /* Check if the watched file has been closed, and 
+    /* Check if the watched file has been closed, and
        XXX-this may not exactly match the kevent() behavior if multiple file de
 scriptors reference the same file.
     */
@@ -198,38 +198,38 @@ scriptors reference the same file.
 
     /* No error checking because fstat(2) should rarely fail */
     //FIXME: EINTR
-    if ((evt.mask & IN_ATTRIB || evt.mask & IN_MODIFY) 
+    if ((evt.mask & IN_ATTRIB || evt.mask & IN_MODIFY)
         && fstat(src->kev.ident, &sb) == 0) {
-        if (sb.st_nlink == 0 && src->kev.fflags & NOTE_DELETE) 
+        if (sb.st_nlink == 0 && src->kev.fflags & NOTE_DELETE)
             dst->fflags |= NOTE_DELETE;
-        if (sb.st_nlink != src->data.vnode.nlink && src->kev.fflags & NOTE_LINK) 
+        if (sb.st_nlink != src->data.vnode.nlink && src->kev.fflags & NOTE_LINK)
             dst->fflags |= NOTE_LINK;
 #if HAVE_NOTE_TRUNCATE
-        if (sb.st_nsize == 0 && src->kev.fflags & NOTE_TRUNCATE) 
+        if (sb.st_nsize == 0 && src->kev.fflags & NOTE_TRUNCATE)
             dst->fflags |= NOTE_TRUNCATE;
 #endif
-        if (sb.st_size > src->data.vnode.size && src->kev.fflags & NOTE_WRITE) 
+        if (sb.st_size > src->data.vnode.size && src->kev.fflags & NOTE_WRITE)
             dst->fflags |= NOTE_EXTEND;
        src->data.vnode.nlink = sb.st_nlink;
        src->data.vnode.size = sb.st_size;
     }
 
-    if (evt.mask & IN_MODIFY && src->kev.fflags & NOTE_WRITE) 
+    if (evt.mask & IN_MODIFY && src->kev.fflags & NOTE_WRITE)
         dst->fflags |= NOTE_WRITE;
-    if (evt.mask & IN_ATTRIB && src->kev.fflags & NOTE_ATTRIB) 
+    if (evt.mask & IN_ATTRIB && src->kev.fflags & NOTE_ATTRIB)
         dst->fflags |= NOTE_ATTRIB;
-    if (evt.mask & IN_MOVE_SELF && src->kev.fflags & NOTE_RENAME) 
+    if (evt.mask & IN_MOVE_SELF && src->kev.fflags & NOTE_RENAME)
         dst->fflags |= NOTE_RENAME;
-    if (evt.mask & IN_DELETE_SELF && src->kev.fflags & NOTE_DELETE) 
+    if (evt.mask & IN_DELETE_SELF && src->kev.fflags & NOTE_DELETE)
         dst->fflags |= NOTE_DELETE;
 
-    if (evt.mask & IN_MODIFY && src->kev.fflags & NOTE_WRITE) 
+    if (evt.mask & IN_MODIFY && src->kev.fflags & NOTE_WRITE)
         dst->fflags |= NOTE_WRITE;
-    if (evt.mask & IN_ATTRIB && src->kev.fflags & NOTE_ATTRIB) 
+    if (evt.mask & IN_ATTRIB && src->kev.fflags & NOTE_ATTRIB)
         dst->fflags |= NOTE_ATTRIB;
-    if (evt.mask & IN_MOVE_SELF && src->kev.fflags & NOTE_RENAME) 
+    if (evt.mask & IN_MOVE_SELF && src->kev.fflags & NOTE_RENAME)
         dst->fflags |= NOTE_RENAME;
-    if (evt.mask & IN_DELETE_SELF && src->kev.fflags & NOTE_DELETE) 
+    if (evt.mask & IN_DELETE_SELF && src->kev.fflags & NOTE_DELETE)
         dst->fflags |= NOTE_DELETE;
 
     return (0);
@@ -252,7 +252,7 @@ evfilt_vnode_knote_create(struct filter *filt, struct knote *kn)
 }
 
 int
-evfilt_vnode_knote_modify(struct filter *filt, struct knote *kn, 
+evfilt_vnode_knote_modify(struct filter *filt, struct knote *kn,
         const struct kevent *kev)
 {
     (void)filt;
@@ -263,7 +263,7 @@ evfilt_vnode_knote_modify(struct filter *filt, struct knote *kn,
 
 int
 evfilt_vnode_knote_delete(struct filter *filt, struct knote *kn)
-{   
+{
     return delete_watch(filt, kn);
 }
 
@@ -288,5 +288,5 @@ const struct filter evfilt_vnode = {
     evfilt_vnode_knote_modify,
     evfilt_vnode_knote_delete,
     evfilt_vnode_knote_enable,
-    evfilt_vnode_knote_disable,        
+    evfilt_vnode_knote_disable,
 };


### PR DESCRIPTION
inotify provides a file descriptor to read events from.

These events are accessed using the usual ``read()`` function, and their sizes are always multiples of `sizeof(struct inotify_event)`.  Their size varies depending on if they contain the name of the file the notification occurred for.  If they do contain a filename the len field will be non-zero and will specify the length of name, rounded up to the next multiple of `sizeof(struct inotify_event)`.

```c
/*
 * struct inotify_event - structure read from the inotify device for each event
 *
 * When you are watching a directory, you will receive the filename for events
 * such as IN_CREATE, IN_DELETE, IN_OPEN, IN_CLOSE, ..., relative to the wd.
 */
struct inotify_event {
	__s32		wd;		/* watch descriptor */
	__u32		mask;		/* watch mask */
	__u32		cookie;		/* cookie to synchronize two events */
	__u32		len;		/* length (including nulls) of name */
	char		name[0];	/* stub for possible name */
};
```

Man inotify(7) states:

> The name field is present only when an event is returned for a file inside a watched directory; it identifies the file pathname relative to the watched directory. This pathname is null-terminated, and may include further null bytes ('\0') to align subsequent reads to a suitable address boundary.

In all other cases when using the inotify API, the len field is 0, and there is no name.  The code as it is today assumes this is always the case, and does not deal with inotify events for files inside of watched directories.  If an inotify event is received for one of these files, the code will abort (see code below):

`src/linux/vnode.c:get_one_event`
```c
dbg_printf("read(2) from inotify wd: %ld bytes", (long) n);

/* FIXME-TODO: if len > 0, read(len) */
if (dst->len != 0) 
        abort();
```

The fix proposed by the comment won't actually work.  If `read()` is provided with a buffer that's too short to contain a complete event (struct inotify_event + name) then `read()` will return -1 with an ``EINVAL`` errno.

If the buffer passed is longer than the complete event, and is long enough to contain another event, the additional events may be lost, as the FD acts more like a stream connection than a datagram based connection and `read()` will dequeue as many complete events as it can until the buffer is filled.

The solution is partially described [here](https://marc.info/?l=linux-man&m=133521752603905&w=2) in a proposed patch to the inotify man pages .  Fortunately we don't have to increment one byte at a time, as the events will always be aligned to multiples of `sizeof(struct inotify_event)`, so we can increment our buffer len in chunks of `sizeof(struct inotify_event)` until read returns successfully.

Reading through the kernel and testing, there does not seem to be a better way of doing this.  For normal inotify events there is no performance impact, but for files in watched directories it may take 2+ read calls to actually get the event.  Still, slow and working is better than fast and broken.

Original fix was by @pwndg but didn't have the correct logic for expanding the buffer incrementally.