### PR TITLE
EOF should be set only on file and stream sockets

### DIFF
--- a/src/common/private.h
+++ b/src/common/private.h
@@ -68,6 +68,7 @@ struct eventfd {
  */
 #define KNFL_PASSIVE_SOCKET  (0x01)  /* Socket is in listen(2) mode */
 #define KNFL_REGULAR_FILE    (0x02)  /* File descriptor is a regular file */
+#define KNFL_STREAM_SOCKET   (0x03)  /* File descriptor is a stream socket */
 #define KNFL_KNOTE_DELETED   (0x10)  /* The knote object is no longer valid */
 
 struct knote {

--- a/src/common/private.h
+++ b/src/common/private.h
@@ -63,16 +63,16 @@ struct eventfd {
 #endif
 };
 
-/* 
+/*
  * Flags used by knote->kn_flags
  */
 #define KNFL_PASSIVE_SOCKET  (0x01)  /* Socket is in listen(2) mode */
 #define KNFL_REGULAR_FILE    (0x02)  /* File descriptor is a regular file */
 #define KNFL_KNOTE_DELETED   (0x10)  /* The knote object is no longer valid */
- 
+
 struct knote {
     struct kevent     kev;
-    int               kn_flags;       
+    int               kn_flags;
     union {
         /* OLD */
         int           pfd;       /* Used by timerfd */
@@ -81,7 +81,7 @@ struct knote {
             nlink_t   nlink;  /* Used by vnode */
             off_t     size;   /* Used by vnode */
         } vnode;
-        timer_t       timerid;  
+        timer_t       timerid;
         struct sleepreq *sleepreq; /* Used by posix/timer.c */
 		void          *handle;      /* Used by win32 filters */
     } data;
@@ -113,7 +113,7 @@ struct filter {
     /* knote operations */
 
     int     (*kn_create)(struct filter *, struct knote *);
-    int     (*kn_modify)(struct filter *, struct knote *, 
+    int     (*kn_modify)(struct filter *, struct knote *,
                             const struct kevent *);
     int     (*kn_delete)(struct filter *, struct knote *);
     int     (*kn_enable)(struct filter *, struct knote *);
@@ -141,7 +141,7 @@ struct filter {
 struct kqueue {
     int             kq_id;
     struct filter   kq_filt[EVFILT_SYSCOUNT];
-    fd_set          kq_fds, kq_rfds; 
+    fd_set          kq_fds, kq_rfds;
     int             kq_nfds;
     tracing_mutex_t kq_mtx;
     volatile uint32_t kq_ref;

--- a/src/linux/platform.c
+++ b/src/linux/platform.c
@@ -300,7 +300,7 @@ linux_get_descriptor_type(struct knote *kn)
 {
     socklen_t slen;
     struct stat sb;
-    int i, lsock;
+    int i, lsock, stype;
 
     /*
      * Test if the descriptor is a socket.
@@ -336,8 +336,19 @@ linux_get_descriptor_type(struct knote *kn)
     } else {
         if (lsock)
             kn->kn_flags |= KNFL_PASSIVE_SOCKET;
-        return (0);
     }
+
+    slen = sizeof(stype);
+    stype = 0;
+    i = getsockopt(kn->kev.ident, SOL_SOCKET, SO_TYPE, (char *) &lsock, &slen);
+    if (i < 0) {
+        dbg_perror("getsockopt(3)");
+        return (-1);
+    }
+    if (stype == SOCK_STREAM)
+        kn->kn_flags |= KNFL_STREAM_SOCKET;
+
+    return (0);
 }
 
 char *

--- a/src/linux/platform.c
+++ b/src/linux/platform.c
@@ -30,10 +30,10 @@ static __thread struct epoll_event epevt[MAX_KEVENT];
 const struct kqueue_vtable kqops = {
     linux_kqueue_init,
     linux_kqueue_free,
-	linux_kevent_wait,
-	linux_kevent_copyout,
-	NULL,
-	NULL,
+    linux_kevent_wait,
+    linux_kevent_copyout,
+    NULL,
+    NULL,
     linux_eventfd_init,
     linux_eventfd_close,
     linux_eventfd_raise,
@@ -89,7 +89,7 @@ linux_kqueue_free(struct kqueue *kq UNUSED)
 
 static int
 linux_kevent_wait_hires(
-        struct kqueue *kq, 
+        struct kqueue *kq,
         const struct timespec *timeout)
 {
     int n;
@@ -128,7 +128,7 @@ linux_kevent_wait_hires(
 
 int
 linux_kevent_wait(
-        struct kqueue *kq, 
+        struct kqueue *kq,
         int nevents,
         const struct timespec *ts)
 {
@@ -144,7 +144,7 @@ linux_kevent_wait(
         timeout = 0;
     } else {
         /* Convert timeout to the format used by epoll_wait() */
-        if (ts == NULL) 
+        if (ts == NULL)
             timeout = -1;
         else
             timeout = (1000 * ts->tv_sec) + (ts->tv_nsec / 1000000);
@@ -185,7 +185,7 @@ linux_kevent_copyout(struct kqueue *kq, int nready,
          * Certain flags cause the associated knote to be deleted
          * or disabled.
          */
-        if (eventlist->flags & EV_DISPATCH) 
+        if (eventlist->flags & EV_DISPATCH)
             knote_disable(filt, kn); //FIXME: Error checking
         if (eventlist->flags & EV_ONESHOT) {
             knote_delete(filt, kn); //FIXME: Error checking
@@ -241,7 +241,7 @@ linux_eventfd_raise(struct eventfd *e)
     counter = 1;
     if (write(e->ef_id, &counter, sizeof(counter)) < 0) {
         switch (errno) {
-            case EAGAIN:    
+            case EAGAIN:
                 /* Not considered an error */
                 break;
 
@@ -269,7 +269,7 @@ linux_eventfd_lower(struct eventfd *e)
     n = read(e->ef_id, &cur, sizeof(cur));
     if (n < 0) {
         switch (errno) {
-            case EAGAIN:    
+            case EAGAIN:
                 /* Not considered an error */
                 break;
 
@@ -334,7 +334,7 @@ linux_get_descriptor_type(struct knote *kn)
                 return (-1);
         }
     } else {
-        if (lsock) 
+        if (lsock)
             kn->kn_flags |= KNFL_PASSIVE_SOCKET;
         return (0);
     }
@@ -369,7 +369,7 @@ epoll_event_dump(struct epoll_event *evt)
 int
 epoll_update(int op, struct filter *filt, struct knote *kn, struct epoll_event *ev)
 {
-    dbg_printf("op=%d fd=%d events=%s", op, (int)kn->kev.ident, 
+    dbg_printf("op=%d fd=%d events=%s", op, (int)kn->kev.ident,
             epoll_event_dump(ev));
     if (epoll_ctl(filter_epfd(filt), op, kn->kev.ident, ev) < 0) {
         dbg_printf("epoll_ctl(2): %s", strerror(errno));

--- a/src/linux/read.c
+++ b/src/linux/read.c
@@ -84,7 +84,7 @@ evfilt_read_copyout(struct kevent *dst, struct knote *src, void *ptr)
                 dbg_perror("inotify_init(2)");
                 (void) close(inofd);
                 return (-1);
-            } 
+            }
             src->kdata.kn_inotifyfd = inofd;
             if (linux_fd_to_path(&path[0], sizeof(path), src->kev.ident) < 0)
                 return (-1);
@@ -114,9 +114,9 @@ evfilt_read_copyout(struct kevent *dst, struct knote *src, void *ptr)
 #endif
     if (ev->events & EPOLLERR)
         dst->fflags = 1; /* FIXME: Return the actual socket error */
-          
+
     if (src->kn_flags & KNFL_PASSIVE_SOCKET) {
-        /* On return, data contains the length of the 
+        /* On return, data contains the length of the
            socket backlog. This is not available under Linux.
          */
         dst->data = 1;
@@ -191,7 +191,7 @@ evfilt_read_knote_create(struct filter *filt, struct knote *kn)
 }
 
 int
-evfilt_read_knote_modify(struct filter *filt, struct knote *kn, 
+evfilt_read_knote_modify(struct filter *filt, struct knote *kn,
         const struct kevent *kev)
 {
     (void) filt;
@@ -267,5 +267,5 @@ const struct filter evfilt_read = {
     evfilt_read_knote_modify,
     evfilt_read_knote_delete,
     evfilt_read_knote_enable,
-    evfilt_read_knote_disable,         
+    evfilt_read_knote_disable,
 };

--- a/src/linux/read.c
+++ b/src/linux/read.c
@@ -131,7 +131,7 @@ evfilt_read_copyout(struct kevent *dst, struct knote *src, void *ptr)
             dst->data = 0;
         } else {
             dst->data = i;
-            if (dst->data == 0)
+            if (dst->data == 0 && src->kn_flags & KNFL_STREAM_SOCKET)
                 dst->flags |= EV_EOF;
         }
     }

--- a/src/windows/platform.c
+++ b/src/windows/platform.c
@@ -46,7 +46,7 @@ const struct kqueue_vtable kqops = {
 int
 windows_kqueue_init(struct kqueue *kq)
 {
-    kq->kq_iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 
+    kq->kq_iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL,
                                          (ULONG_PTR) 0, 0);
     if (kq->kq_iocp == NULL) {
         dbg_lasterror("CreateIoCompletionPort");
@@ -91,7 +91,7 @@ windows_kevent_wait(struct kqueue *kq, int no, const struct timespec *timeout)
 	int retval;
     DWORD       timeout_ms;
     BOOL        success;
-    
+
     if (timeout == NULL) {
         timeout_ms = INFINITE;
     } else if ( timeout->tv_sec == 0 && timeout->tv_nsec < 1000000 ) {
@@ -110,10 +110,10 @@ windows_kevent_wait(struct kqueue *kq, int no, const struct timespec *timeout)
 #if 0
     if(timeout_ms <= 0)
         dbg_printf("Woop, not waiting !?");
-#endif        
+#endif
     memset(&iocp_buf, 0, sizeof(iocp_buf));
-    success = GetQueuedCompletionStatus(kq->kq_iocp, 
-            &iocp_buf.bytes, &iocp_buf.key, &iocp_buf.overlap, 
+    success = GetQueuedCompletionStatus(kq->kq_iocp,
+            &iocp_buf.bytes, &iocp_buf.key, &iocp_buf.overlap,
             timeout_ms);
     if (success) {
         return (1);
@@ -153,7 +153,7 @@ windows_kevent_copyout(struct kqueue *kq, int nready,
      * Certain flags cause the associated knote to be deleted
      * or disabled.
      */
-    if (eventlist->flags & EV_DISPATCH) 
+    if (eventlist->flags & EV_DISPATCH)
         knote_disable(filt, kn); //TODO: Error checking
     if (eventlist->flags & EV_ONESHOT)
         knote_delete(filt, kn); //TODO: Error checking


### PR DESCRIPTION
We recently encountered and issue where our application would hang because libkqueue was signalling 'EOF' on sockets where EOF should not be possible (datagram sockets), and our application was interpreting this as the socket being invalid, and removing it from the event loop.

The socket was not actually invalid, what was happening is that a client was sending zero length UDP packets. i.e. well formed UDP packets with no application data, and libkqueue was incorrectly interpreting the zero length `read()` as an EOF and setting the EV_EOF flag.

This is obviously the wrong behaviour as a zero length UDP packet has no special meaning whatsoever.

For the fix we detect the socket type when the fd is added, and set a flag in the knote, the adjust behaviour if `read()` returns zero based on whether the socket is marked up as a stream socket or not.