### PR TITLE
test/test.c: check if linux is using glibc

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__) && (defined(__GLIBC__) && !defined(__UCLIBC__))
 #include <execinfo.h>
 #endif
 #include <sys/types.h>
@@ -30,7 +30,7 @@ static int error_flag = 1;
 static void
 error_handler(int signum)
 {
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__) && (defined(__GLIBC__) && !defined(__UCLIBC__))
 	void *buf[32];
 
     /* FIXME: the symbols aren't printing */


### PR DESCRIPTION
This will fix building tests on system like Alpine and Void Linux

musl doesn't provide execinfo.h and also doesn't provide a __MUSL__
macro, so we work around it by checking if the system is running
__GLIBC__, we also check if it's not running __UCLIBC__ since uclibc
claims to be __GLIBC__ for compatibility purposes but doesn't actually
provide a working execinfo.h implementation.