### PR TITLE
 Fix FD leak

### DIFF
--- a/src/common/knote.c
+++ b/src/common/knote.c
@@ -100,7 +100,8 @@ knote_delete(struct filter *filt, struct knote *kn)
     }
     pthread_rwlock_unlock(&filt->kf_knote_mtx);
 
-    filt->kn_delete(filt, kn); //XXX-FIXME check return value
+    if (filt->kn_delete(filt, kn) < 0)
+        return (-1);
 
     kn->kn_flags |= KNFL_KNOTE_DELETED;
 

--- a/src/linux/platform.h
+++ b/src/linux/platform.h
@@ -67,6 +67,7 @@ extern long int syscall (long int __sysno, ...);
  */
 #define KNOTE_PLATFORM_SPECIFIC \
     int kn_epollfd; /* A copy of filter->epfd */      \
+    int kn_registered; /* Is FD registered with epoll */ \
     union { \
         int kn_timerfd; \
         int kn_signalfd; \

--- a/src/linux/read.c
+++ b/src/linux/read.c
@@ -213,6 +213,7 @@ evfilt_read_knote_delete(struct filter *filt, struct knote *kn)
         }
         (void) close(kn->kdata.kn_eventfd);
         kn->kdata.kn_eventfd = -1;
+        return (0);
     } else {
         return epoll_update(EPOLL_CTL_DEL, filt, kn, NULL);
     }


### PR DESCRIPTION
On Linux, `kn_eventfd` is currently unregistered in `evfilt_read_copyout` when we get EOF for a regular file.
The fd is also unregistered when removing the event from kqueue with `EV_DELETE`.
This second call fails (as the fd is not found) which causes `evfilt_read_knote_delete` to return an error and not close  `kn_eventfd`.
We therefore get a FD leak.

The fix is to add a `kn_registered` flag to the knote struct (on Linux) and only unregister the FD if it is registered in the first place.

This error was not detected by the unit tests because the return value for `filt->kn_delete` was not checked in `knote_delete`. For all platforms, the delete filter returns an negative value only if an error has occurred. There doesn't seem to be any reason not to propagate the error in `knote_delete`.

With commit https://github.com/mheily/libkqueue/commit/f3c0e3f2a85d9a5865a47db2eb4f39d26b8bd062 the error is detected when running the unit tests.
Commit https://github.com/mheily/libkqueue/commit/c3ada1705ddc6d468a41b4e411a994cdbe85767d then fixes the issue.