### PR TITLE
 Add monitoring thread that takes care of cleaning up closed kqueues

### DIFF
--- a/src/common/filter.c
+++ b/src/common/filter.c
@@ -39,7 +39,7 @@ filter_register(struct kqueue *kq, short filter, const struct filter *src)
     int rv = 0;
 
     filt = (-1 * filter) - 1;
-    if (filt >= EVFILT_SYSCOUNT) 
+    if (filt >= EVFILT_SYSCOUNT)
         return (-1);
 
     dst = &kq->kq_filt[filt];
@@ -73,7 +73,7 @@ filter_register(struct kqueue *kq, short filter, const struct filter *src)
     /* Add the filter's event descriptor to the main fdset */
     if (dst->kf_pfd > 0) {
         FD_SET(dst->kf_pfd, &kq->kq_fds);
-        if (dst->kf_pfd > kq->kq_nfds)  
+        if (dst->kf_pfd > kq->kq_nfds)
             kq->kq_nfds = dst->kf_pfd;
         dbg_printf("fds: added %d (nfds=%d)", dst->kf_pfd, kq->kq_nfds);
     }
@@ -121,7 +121,7 @@ filter_unregister_all(struct kqueue *kq)
         if (kq->kq_filt[i].kf_id == 0)
             continue;
 
-        if (kq->kq_filt[i].kf_destroy != NULL) 
+        if (kq->kq_filt[i].kf_destroy != NULL)
             kq->kq_filt[i].kf_destroy(&kq->kq_filt[i]);
 
         //XXX-FIXME
@@ -160,14 +160,14 @@ filter_name(short filt)
     const char *fname[EVFILT_SYSCOUNT] = {
         "EVFILT_READ",
         "EVFILT_WRITE",
-        "EVFILT_AIO", 
+        "EVFILT_AIO",
         "EVFILT_VNODE",
         "EVFILT_PROC",
-        "EVFILT_SIGNAL", 
-        "EVFILT_TIMER", 
-        "EVFILT_NETDEV", 
-        "EVFILT_FS",    
-        "EVFILT_LIO",  
+        "EVFILT_SIGNAL",
+        "EVFILT_TIMER",
+        "EVFILT_NETDEV",
+        "EVFILT_FS",
+        "EVFILT_LIO",
         "EVFILT_USER"
     };
 

--- a/src/common/filter.c
+++ b/src/common/filter.c
@@ -124,8 +124,7 @@ filter_unregister_all(struct kqueue *kq)
         if (kq->kq_filt[i].kf_destroy != NULL)
             kq->kq_filt[i].kf_destroy(&kq->kq_filt[i]);
 
-        //XXX-FIXME
-        //knote_free_all(&kq->kq_filt[i]);
+        knote_free_all(&kq->kq_filt[i]);
 
         if (kqops.filter_free != NULL)
             kqops.filter_free(kq, &kq->kq_filt[i]);

--- a/src/common/knote.c
+++ b/src/common/knote.c
@@ -147,6 +147,23 @@ knote_get_by_data(struct filter *filt, intptr_t data)
 }
 #endif
 
+int knote_free_all(struct filter *filt)
+{
+    struct knote *kn;
+
+    pthread_rwlock_rdlock(&filt->kf_knote_mtx);
+    RB_FOREACH(kn, knt, &filt->kf_knote) {
+        /* Check return code */
+        filt->kn_delete(filt, kn);
+
+        kn->kn_flags |= KNFL_KNOTE_DELETED;
+
+        knote_release(kn);
+    }
+    pthread_rwlock_unlock(&filt->kf_knote_mtx);
+    return (0);
+}
+
 int
 knote_disable(struct filter *filt, struct knote *kn)
 {

--- a/src/common/kqueue.c
+++ b/src/common/kqueue.c
@@ -35,7 +35,7 @@ pthread_mutex_t kq_mtx = PTHREAD_MUTEX_INITIALIZER;
 pthread_once_t kq_is_initialized = PTHREAD_ONCE_INIT;
 #endif
 
-static unsigned int
+unsigned int
 get_fd_limit(void)
 {
 #ifdef _WIN32

--- a/src/common/kqueue.c
+++ b/src/common/kqueue.c
@@ -126,7 +126,7 @@ kqueue_lookup(int kq)
 int VISIBLE
 kqueue(void)
 {
-	struct kqueue *kq;
+    struct kqueue *kq;
     struct kqueue *tmp;
 
 #ifdef _WIN32
@@ -147,7 +147,7 @@ kqueue(void)
     if (kq == NULL)
         return (-1);
 
-	tracing_mutex_init(&kq->kq_mtx, NULL);
+    tracing_mutex_init(&kq->kq_mtx, NULL);
 
     if (kqops.kqueue_init(kq) < 0) {
         free(kq);

--- a/src/common/kqueue.c
+++ b/src/common/kqueue.c
@@ -161,7 +161,6 @@ kqueue(void)
 
     tmp = map_delete(kqmap, kq->kq_id);
     if (tmp != NULL) {
-        // TODO: kqops.kqueue_free(tmp), or (better yet) decrease it's refcount
         kqops.kqueue_free(tmp);
     }
 

--- a/src/common/private.h
+++ b/src/common/private.h
@@ -184,6 +184,7 @@ extern const struct kqueue_vtable kqops;
 /*
  * knote internal API
  */
+int knote_free_all(struct filter *filt);
 struct knote * knote_lookup(struct filter *, uintptr_t);
 //DEADWOOD: struct knote * knote_get_by_data(struct filter *filt, intptr_t);
 struct knote * knote_new(void);

--- a/src/linux/platform.c
+++ b/src/linux/platform.c
@@ -96,9 +96,12 @@ monitoring_thread_start(void *arg)
     nb_max_fd = get_fd_limit();
 
     sigemptyset(&monitoring_sig_set);
-    sigaddset(&monitoring_sig_set, SIGRTMIN + 1);
+    sigfillset(&monitoring_sig_set);
 
     pthread_sigmask(SIG_BLOCK, &monitoring_sig_set, NULL);
+
+    sigemptyset(&monitoring_sig_set);
+    sigaddset(&monitoring_sig_set, SIGRTMIN + 1);
 
     (void) pthread_mutex_lock(&kq_mtx);
 

--- a/src/linux/platform.h
+++ b/src/linux/platform.h
@@ -66,7 +66,7 @@ extern long int syscall (long int __sysno, ...);
  * Additional members of struct knote
  */
 #define KNOTE_PLATFORM_SPECIFIC \
-    int kn_epollfd; /* A copy of filter->epfd */      \
+    int kn_epollfd;    /* A copy of filter->epfd */ \
     int kn_registered; /* Is FD registered with epoll */ \
     union { \
         int kn_timerfd; \

--- a/src/linux/platform.h
+++ b/src/linux/platform.h
@@ -54,8 +54,8 @@ extern long int syscall (long int __sysno, ...);
 #endif
  
 /* Convenience macros to access the epoll descriptor for the kqueue */
-#define kqueue_epfd(kq)     ((kq)->kq_id)
-#define filter_epfd(filt)   ((filt)->kf_kqueue->kq_id)
+#define kqueue_epfd(kq)     ((kq)->epollfd)
+#define filter_epfd(filt)   ((filt)->kf_kqueue->epollfd)
 
 /*
  * Additional members of struct filter
@@ -79,6 +79,8 @@ extern long int syscall (long int __sysno, ...);
  * Additional members of struct kqueue
  */
 #define KQUEUE_PLATFORM_SPECIFIC \
+    int epollfd;       /* Main epoll FD */ \
+    int pipefd[2];     /* FD for pipe that catches close */ \
     struct epoll_event kq_plist[MAX_KEVENT]; \
     size_t kq_nplist
 


### PR DESCRIPTION
On BSD/Mac systems, when closing a kqueue fd, the underlying resources are freed.
This currently isn't the case on Linux.
This pull request works around this (on Linux) by adding an intermediate pipe.

A close on the write end of a pipe can be caught using signals.
The proposed change adds a "monitoring" thread that listens on real time signals attached to the pipe.
The pipe FD is used as the kqueue identifier. That way, we get notified when the kqueue is closed and can free any resources attached to it.

The "monitoring" thread is started when the first kqueue is created and stopped when the last kqueue is closed.

The down side to this approach is that we use 3 FDs for every kqueue but under normal circumstances, we'll only have a limited number of kqueues being used simultaneously.

Comments are welcome.