### PR TITLE
Fix compilation with GCC 8.1 (and fix warning)

### DIFF
--- a/src/common/kevent.c
+++ b/src/common/kevent.c
@@ -62,7 +62,7 @@ kevent_fflags_dump(const struct kevent *kev)
         KEVFFL_DUMP(NOTE_FFCOPY);
         KEVFFL_DUMP(NOTE_TRIGGER);
     }  else {
-        strncat((char *) &buf[0], " ", 1);
+        buf[0] = ' ';
     }
     buf[strlen(buf) - 1] = ')';
 
@@ -101,7 +101,7 @@ kevent_flags_dump(const struct kevent *kev)
 const char *
 kevent_dump(const struct kevent *kev)
 {
-    static __thread char buf[1024];
+    static __thread char buf[4096];
 
     snprintf((char *) &buf[0], sizeof(buf), 
             "{ ident=%d, filter=%s, %s, %s, data=%d, udata=%p }",

--- a/test/test.c
+++ b/test/test.c
@@ -19,6 +19,7 @@
 #endif
 #include <sys/types.h>
 #include <limits.h>
+#include <execinfo.h>
 
 #include "common.h"
 


### PR DESCRIPTION
This might not be the greatest code, but it does fix compilation with GCC 8.1 (reported in #46) and also fixes a warning in `test.c`.

Only tested on Debian testing with GCC 8.1.0. Test is successful.