### PR TITLE
fix debian packaging to create shlibs file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ endif()
 
 add_library(kqueue ${LIBRARY_TYPE} ${LIBKQUEUE_SOURCES} ${LIBKQUEUE_HEADERS})
 set_target_properties(kqueue PROPERTIES DEBUG_POSTFIX "d")
-set_target_properties(kqueue PROPERTIES SOVERSION 0)
+set_target_properties(kqueue PROPERTIES SOVERSION 1)
 
 if(WIN32)
   target_compile_definitions(kqueue PRIVATE _USRDLL;_WINDLL)
@@ -268,6 +268,8 @@ set(CPACK_DEBIAN_DEVEL_PACKAGE_DEPENDS "${CPACK_PACKAGE_NAME} (= ${PROJECT_VERSI
 
 set(CPACK_DEB_COMPONENT_INSTALL ON)             # Enable component based packaging (generate multiple packages)
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)         # Use default Debian package naming scheme
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS ON)
 
 include(CPack)
 


### PR DESCRIPTION
This adds the GENERATE_SHLIBS CMake variable.  This allows other debian packages to use dpkg-shlibdeps to determine information from the generated .deb file

Big problem.  The version of CMake that I'm using does not allow you to use 0 as an SOVERSION number so I also had to bump the SOVERSION to 1.  We could set to something like "0.1" but 0 or "0" is apparently right out. 

With an SOVERSION of 1 it works great, but with an SOVERSION of 0 you get this error
`CMake Warning (dev) at /usr/local/share/cmake-3.8/Modules/CPackDeb.cmake:919 (message):
  Shared library './usr/lib/libkqueue.so.0' is missing soname or soversion.
  Library will not be added to DEBIAN/shlibs control file.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.8/Modules/CPackDeb.cmake:1049 (cpack_deb_prepare_package_vars)
This warning is for project developers.  Use -Wno-dev to suppress it.`