### PR TITLE
kqueue.2: NOTE_LOWAT is #undef'd

### DIFF
--- a/kqueue.2
+++ b/kqueue.2
@@ -266,11 +266,14 @@ subject to the
 value of the socket buffer.
 This may be overridden with a per-filter low water mark at the
 time the filter is added by setting the
-NOTE_LOWAT
+.Dv NOTE_LOWAT
 flag in
 .Va fflags ,
 and specifying the new low water mark in
 .Va data .
+.Sy This is not supported by libkqueue .
+.Dv SO_RCVLOWAT
+may be ignored on Linux.
 On return,
 .Va data
 contains the number of bytes of protocol data available to read.


### PR DESCRIPTION
This PR adjusts the bundled `kqueue.2` to note that `NOTE_LOWAT` is #undef'd in the relevant header. It also notes that `SO_RCVLOWAT` may be ignored on Linux, cf. [socket(7)](http://man7.org/linux/man-pages/man7/socket.7.html):

> The select(2) and poll(2) system calls currently do not respect the SO_RCVLOWAT setting on Linux, and mark a socket readable when even a single byte of data is available.  A subsequent read from the socket will block until SO_RCVLOWAT bytes are available.