### PR TITLE
cmake: remove manual lib64 suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,15 +103,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
     set (CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "default install path" FORCE )
   endif()
 
-  #
-  #  Set library directory correctly if we're building 64bit libraries
-  #
-  get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-  if ("${LIB64}" STREQUAL "TRUE")
-    set(LIB_SUFFIX 64)
-  else()
-    set(LIB_SUFFIX "")
-  endif()
   list(APPEND LIBKQUEUE_SOURCES
        src/posix/platform.c
        src/posix/platform.h
@@ -182,7 +173,7 @@ configure_file("${CMAKE_SOURCE_DIR}/libkqueue.pc.in"
 set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION ${CMAKE_INSTALL_FULL_MANDIR}
                                                   ${CMAKE_INSTALL_FULL_MANDIR}/man2
                                                   ${CMAKE_INSTALL_FULL_INCLUDEDIR}/sys
-                                                  ${CMAKE_INSTALL_FULL_LIBDIR}${LIB_SUFFIX}/pkgconfig)
+                                                  ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
 
 install(FILES
           "include/sys/event.h"
@@ -192,7 +183,7 @@ install(FILES
 install(TARGETS
           kqueue
         DESTINATION
-          "${CMAKE_INSTALL_FULL_LIBDIR}${LIB_SUFFIX}"
+          "${CMAKE_INSTALL_FULL_LIBDIR}"
         COMPONENT libraries)
 install(FILES
           kqueue.2
@@ -202,7 +193,7 @@ install(FILES
 install(FILES
           "${CMAKE_BINARY_DIR}/libkqueue.pc"
         DESTINATION
-          "${CMAKE_INSTALL_FULL_LIBDIR}${LIB_SUFFIX}/pkgconfig"
+          "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig"
         COMPONENT pkgconfig)
 
 set(CPACK_PACKAGE_NAME ${PROJECT_NAME})


### PR DESCRIPTION
CMake handles adding this suffix itself when necessary.
When I built from source without this patch, libs were being
installed into /usr/local/lib6464.
Many distros use /usr/lib even for 64 bit libs (e.g. Debian, Void);
without this patch they would need to do manual work to move the
libraries back to where they belong.