### PR TITLE
Detect raw sockets

### DIFF
--- a/src/common/private.h
+++ b/src/common/private.h
@@ -75,11 +75,13 @@ struct eventfd {
 #define KNFL_SOCKET_DGRAM        (1U << 6U)
 #define KNFL_SOCKET_RDM          (1U << 7U)
 #define KNFL_SOCKET_SEQPACKET    (1U << 8U)
+#define KNFL_SOCKET_RAW          (1U << 9U)
 #define KNFL_KNOTE_DELETED       (1U << 31U)
 #define KNFL_SOCKET              (KNFL_SOCKET_STREAM |\
                                   KNFL_SOCKET_DGRAM |\
                                   KNFL_SOCKET_RDM |\
-                                  KNFL_SOCKET_SEQPACKET)
+                                  KNFL_SOCKET_SEQPACKET |\
+                                  KNFL_SOCKET_RAW)
 
 struct knote {
     struct kevent     kev;

--- a/src/linux/platform.c
+++ b/src/linux/platform.c
@@ -558,6 +558,7 @@ linux_eventfd_descriptor(struct eventfd *e)
  * - KNFL_SOCKET_DGRAM       FD is a datagram socket (unreliable connectionless messages).
  * - KNFL_SOCKET_RDM         FD is a reliable datagram socket (reliable connectionless messages).
  * - KNFL_SOCKET_SEQPACKET   FD is a sequenced packet socket (reliable connection-oriented messages).
+ * - KNFL_SOCKET_RAW         FD is a raw socket as documented in raw(7).
  *
  * Additionally KNFL_SOCKET_* types may have the KNFL_SOCKET_PASSIVE flag set if they
  * are never expected to return data, but only provide an indication of whether data is available.

--- a/src/linux/platform.c
+++ b/src/linux/platform.c
@@ -649,6 +649,11 @@ linux_get_descriptor_type(struct knote *kn)
             kn->kn_flags |= KNFL_SOCKET_SEQPACKET;
             break;
 
+        case SOCK_RAW:
+            dbg_printf("fd %d is a raw socket\n", fd);
+            kn->kn_flags |= KNFL_SOCKET_RAW;
+            break;
+
         default:
             errno = EBADF;
             dbg_perror("unknown socket type");


### PR DESCRIPTION
This prevents an error when a raw socket is encountered. I have not looked at whether additional special cases are needed for handling raw sockets.