### PR TITLE
Fix kevent_add() failed on CentOS 6

### DIFF
--- a/src/linux/platform.c
+++ b/src/linux/platform.c
@@ -677,24 +677,27 @@ linux_get_descriptor_type(struct knote *kn)
         kn->kn_flags |= KNFL_SOCKET_PASSIVE;
 
 #ifdef SO_GET_FILTER
-    /*
-     * Test if socket has a filter
-     * pcap file descriptors need to be considered as passive sockets as
-     * SIOCINQ always returns 0 even if data is available.
-     * Looking at SO_GET_FILTER is a good way of doing this.
-     */
-    socklen_t out_len = 0;
-    ret = getsockopt(fd, SOL_SOCKET, SO_GET_FILTER, NULL, &out_len);
-    if (ret < 0) {
-        switch (errno) {
-            case ENOTSOCK:   /* same as lsock = 0 */
-                break;
-            default:
-                dbg_perror("getsockopt(3)");
-                return (-1);
-        }
-    } else if (out_len)
-        kn->kn_flags |= KNFL_SOCKET_PASSIVE;
+    {
+        socklen_t out_len = 0;
+        
+        /*
+         * Test if socket has a filter
+         * pcap file descriptors need to be considered as passive sockets as
+         * SIOCINQ always returns 0 even if data is available.
+         * Looking at SO_GET_FILTER is a good way of doing this.
+         */
+        ret = getsockopt(fd, SOL_SOCKET, SO_GET_FILTER, NULL, &out_len);
+        if (ret < 0) {
+            switch (errno) {
+                case ENOTSOCK:   /* same as lsock = 0 */
+                    break;
+                default:
+                    dbg_perror("getsockopt(3)");
+                    return (-1);
+            }
+        } else if (out_len)
+            kn->kn_flags |= KNFL_SOCKET_PASSIVE;
+    }
 #endif /* SO_GET_FILTER */
 
     return (0);


### PR DESCRIPTION
kevent_add() was failed on CentOS 6.8 due to error of getsockopt(SO_GET_FILTER) in linux_get_descriptor_type().

The SO_GET_FILTER option was introduced since Linux kernel 3.8, which would be defined as SO_ATTACH_FILTER in src/linux/platform.c, causing the getsockopt() failed.

Currently this library is totally not working on CentOS 6.8 (maybe all linux kernel < 3.8) because of this problem. But this patch makes it possible to use this library on CentOS 6.8 with kernel 2.6.32 or even lower. The only drawback is that it cannot determine whether a file descriptor is passive by checking BPF filter on linux kernel under 3.8.

This patch makes no difference to kernel >= 3.8.

Fix #72 