### PR TITLE
build: Allow set CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,10 @@ set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
 
 option(STATIC_KQUEUE "build libkqueue as static library" OFF)
 


### PR DESCRIPTION
It allows to build in debug mode like:

e.g: cmake -DCMAKE_BUILD_TYPE=Debug ...