### PR TITLE
Use prctl() to set names on threads for Linux and POSIX

### DIFF
--- a/src/linux/proc.c
+++ b/src/linux/proc.c
@@ -21,6 +21,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/prctl.h>
 #include <sys/queue.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -135,6 +136,10 @@ evfilt_proc_init(struct filter *filt)
     if (pthread_create(&ed->wthr_id, NULL, wait_thread, filt) != 0)
         goto errout;
 
+    /* Set the thread's name to something descriptive so it shows up in gdb,
+     * etc. glibc >= 2.1.2 supports pthread_setname_np, but this is a safer way
+     * to do it for backwards compatibility. Max name length is 16 bytes. */
+    prctl(PR_SET_NAME, "libkqueue_wait", 0, 0, 0);
 
     return (0);
 

--- a/src/posix/proc.c
+++ b/src/posix/proc.c
@@ -21,6 +21,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/prctl.h>
 #include <sys/queue.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -114,6 +115,10 @@ evfilt_proc_init(struct filter *filt)
         goto errout;
     if (pthread_create(&ed->wthr_id, NULL, wait_thread, filt) != 0)
         goto errout;
+
+    /* Set the thread's name to something descriptive so it shows up in gdb,
+     * etc. Max name length is 16 bytes. */
+    prctl(PR_SET_NAME, "libkqueue_wait", 0, 0, 0);
 
     return (0);
 

--- a/src/posix/timer.c
+++ b/src/posix/timer.c
@@ -20,6 +20,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/prctl.h>
 #include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -166,6 +167,10 @@ _timer_create(struct filter *filt, struct knote *kn)
         free(req);
         return (-1);
     }
+    /* Set the thread's name to something descriptive so it shows up in gdb,
+     * etc. Max name length is 16 bytes. */
+    prctl(PR_SET_NAME, "libkqueue_sleep", 0, 0, 0);
+
     pthread_attr_destroy(&attr);
 
     return (0);


### PR DESCRIPTION
Sample output:

```
(lldb) thread list
Process 24169 stopped
* thread #1: tid = 24169, 0x00007fa847a10bf6 libc.so.6`ppoll + 166, name = 'libkqueue_mon', stop reason = signal SIGSTOP
```

This is on a ubuntu 20.04 machine.