### PR TITLE
Use a rwlock instead of atomics in map.c

### DIFF
--- a/src/common/private.h
+++ b/src/common/private.h
@@ -259,8 +259,6 @@ int             kqueue_validate(struct kqueue *);
 
 struct map      *map_new(size_t);
 int             map_insert(struct map *, int, void *);
-int             map_remove(struct map *, int, void *);
-int             map_replace(struct map *, int, void *, void *);
 void            *map_lookup(struct map *, int);
 void            *map_delete(struct map *, int);
 void            map_free(struct map *);


### PR DESCRIPTION
I don't see a good reason to use atomic operations in map.c.

Let's use a rwlock instead.