### PR TITLE
use correct output dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ execute_process(COMMAND git rev-parse --short=8 HEAD
 project(libkqueue VERSION ${PROJECT_VERSION}
                   LANGUAGES C)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/sys/libkqueue_version.h.in
-               ${CMAKE_CURRENT_SOURCE_DIR}/include/sys/libkqueue_version.h @ONLY)
+               ${CMAKE_CURRENT_BINARY_DIR}/include/sys/libkqueue_version.h @ONLY)
 
 enable_testing()
 


### PR DESCRIPTION
1827333322cdc00794fb7ffd33a5af2d63591749 broke all our .DEB package builds (but weirdly not RPMs) - this fixes it (tested on debian10+11, ubuntu20 + centos8)