### PR TITLE
Added fflags for EVFILT_TIMER to 'kevent_fflags_dump'

### DIFF
--- a/src/common/kevent.c
+++ b/src/common/kevent.c
@@ -76,6 +76,13 @@ kevent_fflags_dump(const struct kevent *kev)
         KEVFFL_DUMP(NOTE_EXEC);
         break;
 
+    case EVFILT_TIMER:
+        KEVFFL_DUMP(NOTE_SECONDS);
+        KEVFFL_DUMP(NOTE_USECONDS);
+        KEVFFL_DUMP(NOTE_NSECONDS);
+        KEVFFL_DUMP(NOTE_ABSOLUTE);
+        break;
+
     default:
         break;
     }


### PR DESCRIPTION
This addresses issue #118 by adding the set of fflags used for `EVFILT_TIMER` such as `NOTE_NSECONDS`, et al.