### PR TITLE
Correctly Scale useconds to nseconds when NOTE_USECONDS is Asserted

### DIFF
--- a/src/linux/timer.c
+++ b/src/linux/timer.c
@@ -93,7 +93,7 @@ convert_timedata_to_itimerspec(struct itimerspec *dst, long src,
     switch (flags & NOTE_TIMER_MASK) {
     case NOTE_USECONDS:
         sec = src / 1000000;
-        nsec = (src % 1000000);
+        nsec = (src % 1000000) * 1000;
         break;
 
     case NOTE_NSECONDS:


### PR DESCRIPTION
Address issue #120 by scaling by 1,000 the microseconds value to correctly match the required nanosecond field required by the itimerspec structure when `NOTE_USECONDS` of `fflags`.