### PR TITLE
Add CI flow for Windows

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,28 @@
+name: CI Windows
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  KQUEUE_DEBUG: yes
+
+jobs:
+  windows-build:
+    runs-on: windows-2019
+    name: CI-windows (build)
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure build system
+        run: |
+          cmake --version
+          cmake -S . -B build_x64 -A x64 -G "Visual Studio 16 2019" -DSTATICLIB=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON
+
+      - name: Build libkqueue
+        run: |
+          cmake --build build_x64 --target install --config Release --parallel 1
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ libkqueue
 [![CI Linux](https://github.com/mheily/libkqueue/actions/workflows/ci-linux.yml/badge.svg)](https://github.com/mheily/libkqueue/actions/workflows/ci-linux.yml)
 [![CI tests FreeBSD](https://github.com/mheily/libkqueue/actions/workflows/ci-freebsd.yml/badge.svg)](https://github.com/mheily/libkqueue/actions/workflows/ci-freebsd.yml)
 [![CI tests macOS](https://github.com/mheily/libkqueue/actions/workflows/ci-macos.yml/badge.svg)](https://github.com/mheily/libkqueue/actions/workflows/ci-macos.yml)
+[![CI tests Windows](https://github.com/mheily/libkqueue/actions/workflows/ci-windows.yml/badge.svg)](https://github.com/mheily/libkqueue/actions/workflows/ci-windows.yml)
 
 A user space implementation of the kqueue(2) kernel event notification mechanism
 libkqueue acts as a translator between the kevent structure and the native

--- a/src/common/private.h
+++ b/src/common/private.h
@@ -99,6 +99,7 @@ struct evfilt_data;
 #define unlikely(x)     (x)
 #define VISIBLE
 #define HIDDEN
+#define UNUSED
 #define UNUSED_NDEBUG
 #endif
 


### PR DESCRIPTION
It enables the CI for Windows. therefore, without the tests due to be necessary extra pokes for windows that will be submitted separately.