### PR TITLE
Only run Coverity build on the main repository

### DIFF
--- a/.github/workflows/ci-linux-coverity.yml
+++ b/.github/workflows/ci-linux-coverity.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   linux-build-and-test:
+    if: github.repository == 'mheily/libkqueue'
     timeout-minutes: 5
     strategy:
       fail-fast: false


### PR DESCRIPTION
This avoids trying to run the Coverity CI job on forks. I tried to make this keyed on whether or not the token existed but that'd require having the setup on the Coverity side anyways to update the reports so this is enough.