### PR TITLE
fix compilation with MSYS2

### DIFF
--- a/include/sys/event.h
+++ b/include/sys/event.h
@@ -257,7 +257,7 @@ extern "C" {
 
 #ifdef _WIN32
 
-#if (_MSC_VER < 1900)
+#if defined (_MSC_VER) && (_MSC_VER < 1900)
 struct timespec {
     time_t  tv_sec;
     long    tv_nsec;

--- a/src/windows/platform.h
+++ b/src/windows/platform.h
@@ -18,7 +18,9 @@
 #define  _KQUEUE_WINDOWS_PLATFORM_H
 
 /* Require Windows Server 2003 or later */
+#if WINVER < 0x0502
 #define WINVER 0x0502
+#endif
 #ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0502
 #endif
@@ -28,6 +30,7 @@
 #include <io.h>
 #include <malloc.h>
 #include <sys/stat.h>
+#include <errno.h>
 
 #include "../common/queue.h"
 


### PR DESCRIPTION
First change fixes a redefinition error.

Second one fixes missing definition for EINVAL and such.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

remaining warnings:

```
../subprojects/libkqueue-2.6.1/src/common/private.h:105:9: warning: 'VISIBLE' macro redefined [-Wmacro-redefined]
#define VISIBLE         __attribute__((visibility("default")))
        ^
../subprojects/libkqueue-2.6.1/src/common/../windows/platform.h:110:9: note: previous definition is here
#define VISIBLE __declspec(dllexport)
        ^
In file included from ../subprojects/libkqueue-2.6.1/src/common/libkqueue.c:16:
../subprojects/libkqueue-2.6.1/src/common/private.h:106:9: warning: 'HIDDEN' macro redefined [-Wmacro-redefined]
#define HIDDEN          __attribute__((visibility("hidden")))
        ^
../subprojects/libkqueue-2.6.1/src/common/../windows/platform.h:111:9: note: previous definition is here
#define HIDDEN
        ^
2 warnings generated.

```