### PR TITLE
debug: move private include up

### DIFF
--- a/src/windows/platform.h
+++ b/src/windows/platform.h
@@ -17,6 +17,8 @@
 #ifndef  _KQUEUE_WINDOWS_PLATFORM_H
 #define  _KQUEUE_WINDOWS_PLATFORM_H
 
+#include "config.h"
+
 /* Require Windows Server 2003 or later */
 #if WINVER < 0x0502
 #define WINVER 0x0502


### PR DESCRIPTION
private.h includes config.h, which is in turn required by windows/platform.h as it checks for sys/types.h