### PR TITLE
Check if libstdatomic is needed to link on the target platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
@@ -277,6 +279,7 @@ if(WIN32)
   target_compile_definitions(objlib PRIVATE _CRT_SECURE_NO_WARNINGS)
   target_compile_definitions(objlib PRIVATE WIN32_LEAN_AND_MEAN)
 else()
+  include(StdAtomicCheck)
   target_compile_definitions(objlib PRIVATE _XOPEN_SOURCE=600)
 endif()
 

--- a/cmake/StdAtomicCheck.cmake
+++ b/cmake/StdAtomicCheck.cmake
@@ -1,0 +1,50 @@
+# Check if _Atomic needs -latomic
+
+set(LIBATOMIC_STATIC_PATH "" CACHE PATH "Directory containing static libatomic.a")
+
+include(CheckCSourceCompiles)
+
+set(
+  check_std_atomic_source_code
+  [=[
+  #include <stdatomic.h>
+  _Atomic long long x = 0;
+  atomic_uint y = 0;
+  void test(_Atomic long long *x, long long v) {
+      atomic_store(x, v);
+      y = v + 1;
+  }
+  int main(int argc, char **argv) {
+      test(&x, argc);
+      return 0;
+  }
+  ]=])
+
+check_c_source_compiles("${check_std_atomic_source_code}" std_atomic_without_libatomic)
+
+if(NOT std_atomic_without_libatomic)
+  set(CMAKE_REQUIRED_LIBRARIES atomic)
+  check_c_source_compiles("${check_std_atomic_source_code}" std_atomic_with_libatomic)
+  set(CMAKE_REQUIRED_LIBRARIES)
+  if(NOT std_atomic_with_libatomic)
+    message(FATAL_ERROR "Toolchain doesn't support C11 _Atomic with nor without -latomic")
+  else()
+    find_library(ATOMIC_STATIC NAMES libatomic.a PATHS /usr/lib /usr/local/lib ${LIBATOMIC_STATIC_PATH} NO_DEFAULT_PATH)
+    if(ATOMIC_STATIC)
+      get_filename_component(ATOMIC_STATIC_DIR "${ATOMIC_STATIC}" DIRECTORY)
+      get_filename_component(ATOMIC_STATIC_NAME "${ATOMIC_STATIC}" NAME)
+      message(STATUS "Linking static libatomic: -L${ATOMIC_STATIC_DIR} -l:${ATOMIC_STATIC_NAME}")
+      set(EXTRA_PRIVATE_LIBS "-L${ATOMIC_STATIC_DIR} -l:${ATOMIC_STATIC_NAME}")
+      if(ENABLE_SHARED)
+        target_link_directories(kqueue PRIVATE "${ATOMIC_STATIC_DIR}")
+        target_link_libraries(kqueue PRIVATE "-l:${ATOMIC_STATIC_NAME}")
+      endif()
+    else()
+      message(WARNING "static libatomic not found; falling back to -latomic")
+      set(EXTRA_PRIVATE_LIBS "-latomic")
+      if(ENABLE_SHARED)
+        target_link_libraries(kqueue PRIVATE atomic)
+      endif()
+    endif()
+  endif()
+endif()

--- a/libkqueue.pc.in
+++ b/libkqueue.pc.in
@@ -8,5 +8,5 @@ Description: Emulates FreeBSD kqueue(2) on other platforms
 Version: @PROJECT_VERSION@
 Requires:
 Libs: -L${libdir} -lkqueue
-Libs.private: -lpthread -lrt
+Libs.private: -lpthread -lrt @EXTRA_PRIVATE_LIBS@
 Cflags: -I${includedir}/kqueue


### PR DESCRIPTION
Hi, thanks for the useful library. I am the author and maintainer of the Qemu fork allowing to run FreeBSD binaries to run unmodified on any modern Linux installation and recently somebody has submitted kqueue(2) emulation support using your library (https://github.com/sobomax/qemu-bsd-user-l4b). 

Upon adding the library to the build I noticed 3 issues:

1. The GH Actions script is outdated, resulting in the test refusing to run (ubuntu-20.04 has been discontinued few months ago and 18.04 two years ago). See #158 for the fix.
2. We would like to build a static library only. So I've added #159 to add.
3. The linking would fail on linux/arm/v5 (debian:12), this is due to the platform not providing stdatomic as part of toolchain and needed an external library. To make matters worse, the static version of the said library is well hidden for some reason, requiring custom -L flag to dig it out. I've encountered this issue building arm/v5 version of other packages, so check for the need of -lstdatomic is added as well as some logic to provide path to the static library when desired.
```
#70 1610.9 FAILED: qemu-x86_64 
#70 1610.9 clang-19  -o qemu-x86_64 libcommon.a.p/gdbstub_syscalls.c.o libcommon.a.p/hw_core_cpu-common.c.o libcommon.a.p/hw_core_machine-smp.c.o libcommon.a.p/cpu-common.c.o libcommon.a.p/page-vary-common.c.o libcommon.a.p/disas_disas-host.c.o libcommon.a.p/disas_disas-target.c.o libcommon.a.p/disas_objdump.c.o libcommon.a.p/disas_disas-common.c.o libcommon.a.p/semihosting_stubs-all.c.o libcommon.a.p/accel_tcg_cpu-exec-common.c.o libcommon.a.p/accel_accel-user.c.o libcommon.a.p/common-user_safe-syscall.S.o libcommon.a.p/common-user_safe-syscall-error.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_user_excp_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_user_seg_helper.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_x86_64_signal.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_x86_64_target_arch_cpu.c.o libqemu-x86_64-bsd-user.a.p/target_i386_cpu.c.o libqemu-x86_64-bsd-user.a.p/target_i386_gdbstub.c.o libqemu-x86_64-bsd-user.a.p/target_i386_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_xsave_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_cpu-dump.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_access.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_bpt_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_cc_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_excp_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_fpu_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_int_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_mem_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_misc_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_mpx_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_seg_helper.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_tcg-cpu.c.o libqemu-x86_64-bsd-user.a.p/target_i386_tcg_translate.c.o libqemu-x86_64-bsd-user.a.p/trace_control-target.c.o libqemu-x86_64-bsd-user.a.p/gdbstub_user-target.c.o libqemu-x86_64-bsd-user.a.p/cpu-target.c.o libqemu-x86_64-bsd-user.a.p/page-target.c.o libqemu-x86_64-bsd-user.a.p/page-vary-target.c.o libqemu-x86_64-bsd-user.a.p/fpu_softfloat.c.o libqemu-x86_64-bsd-user.a.p/accel_accel-target.c.o libqemu-x86_64-bsd-user.a.p/accel_tcg_tcg-all.c.o libqemu-x86_64-bsd-user.a.p/accel_tcg_cpu-exec.c.o libqemu-x86_64-bsd-user.a.p/accel_tcg_tb-maint.c.o libqemu-x86_64-bsd-user.a.p/accel_tcg_tcg-runtime-gvec.c.o libqemu-x86_64-bsd-user.a.p/accel_tcg_tcg-runtime.c.o libqemu-x86_64-bsd-user.a.p/accel_tcg_translate-all.c.o libqemu-x86_64-bsd-user.a.p/accel_tcg_translator.c.o libqemu-x86_64-bsd-user.a.p/accel_tcg_user-exec.c.o libqemu-x86_64-bsd-user.a.p/accel_tcg_user-exec-stub.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_bsd-ioctl.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_bsd-mem.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_bsd-proc.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_bsd-socket.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_bsdload.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_elfload.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_main.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_mmap.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_thunk.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_signal.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_uaccess.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_linux_os-proc.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_linux_os-socket.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_linux_os-stat.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_linux_os-sys.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_linux_os-syscall.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_linux_os-thread.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_linux_os-time.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_linux_os-file.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_linux_truss.c.o libqemu-x86_64-bsd-user.a.p/bsd-user_linux_os-dev_proc.c.o libqemu-x86_64-bsd-user.a.p/meson-generated_.._x86_64-bsd-user-gdbstub-xml.c.o libhwcore.a.p/hw_core_bus.c.o libhwcore.a.p/hw_core_qdev-properties.c.o libhwcore.a.p/hw_core_qdev.c.o libhwcore.a.p/hw_core_resetcontainer.c.o libhwcore.a.p/hw_core_resettable.c.o libhwcore.a.p/hw_core_vmstate-if.c.o libhwcore.a.p/hw_core_irq.c.o libhwcore.a.p/hw_core_clock.c.o libhwcore.a.p/hw_core_qdev-clock.c.o libqom.a.p/qom_container.c.o libqom.a.p/qom_object.c.o libqom.a.p/qom_object_interfaces.c.o libqom.a.p/qom_qom-qobject.c.o libevent-loop-base.a.p/event-loop-base.c.o gdbstub/libgdb_user.a.p/gdbstub.c.o gdbstub/libgdb_user.a.p/user.c.o tcg/libtcg_user.a.p/optimize.c.o tcg/libtcg_user.a.p/region.c.o tcg/libtcg_user.a.p/tcg.c.o tcg/libtcg_user.a.p/tcg-common.c.o tcg/libtcg_user.a.p/tcg-op.c.o tcg/libtcg_user.a.p/tcg-op-ldst.c.o tcg/libtcg_user.a.p/tcg-op-gvec.c.o tcg/libtcg_user.a.p/tcg-op-vec.c.o tcg/libtcg_user.a.p/perf.c.o -Wl,--as-needed -Wl,--no-undefined -static -fstack-protector-strong -Wl,-z,relro -Wl,-z,now -O1 -pipe -ffunction-sections -fdata-sections -DHAVE_BSD_STRING_H=1 -Wno-atomic-alignment -Wl,--gc-sections -Wl,--start-group -lbsd -lmd libqemuutil.a /usr/local/lib/libkqueue.a -lpthread -lrt /usr/lib/arm-linux-gnueabi/libelf.a -lm -pthread /usr/lib/arm-linux-gnueabi/libglib-2.0.a /usr/lib/arm-linux-gnueabi/libpcre2-8.a -Wl,--end-group
#70 1610.9 /usr/bin/arm-linux-gnueabi-ld: /usr/lib/arm-linux-gnueabi/libglib-2.0.a(gutils.c.o): in function `g_get_user_database_entry':
#70 1610.9 (.text+0x2b0): warning: Using 'getpwuid' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
#70 1610.9 /usr/bin/arm-linux-gnueabi-ld: (.text+0xf0): warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
#70 1610.9 /usr/bin/arm-linux-gnueabi-ld: (.text+0x130): warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
#70 1610.9 /usr/bin/arm-linux-gnueabi-ld: /usr/local/lib/libkqueue.a(knote.c.o): in function `knote_new':
#70 1610.9 /tmp/libkqueue/src/common/knote.c:52: undefined reference to `__atomic_store'
```

With those 3 changes I have been able to build my Qemu fork against libkqueue and confirm it works on linux/386, linux/amd64, linux/arm/v5 and linux/arm64/v8. That being said, I have not tested any kqueue functionality specifically.