### PR TITLE
Check for invalid filter index in windows_kevent_copyout

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -36,9 +36,8 @@ jobs:
       - name: Configure build system
         run: |
           cmake --version
-          cmake -S . -B build_x64 -A x64 -G "Visual Studio 16 2019" -DSTATICLIB=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON
+          cmake -S . -B build_x64 -A x64 -G "Visual Studio 17 2022" -DSTATICLIB=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON
 
       - name: Build libkqueue
         run: |
           cmake --build build_x64 --target install --config Release --parallel 1
-

--- a/src/windows/platform.c
+++ b/src/windows/platform.c
@@ -134,11 +134,17 @@ windows_kevent_copyout(struct kqueue *kq, int nready,
 {
     struct filter *filt;
     struct knote* kn;
-    int rv, nret;
+    int rv, nret, filt_index;
 
     //FIXME: not true for EVFILT_IOCP
     kn = (struct knote *) iocp_buf.overlap;
-    filt = &kq->kq_filt[~(kn->kev.filter)];
+    filt_index = ~(kn->kev.filter);
+    if (filt_index < 0 || filt_index >= EVFILT_SYSCOUNT) {
+        dbg_puts("bad filter index in windows_kevent_copyout");
+        return 0;
+    }
+    filt = &kq->kq_filt[filt_index];
+
     rv = filt->kf_copyout(eventlist, nevents, filt, kn, &iocp_buf);
     if (unlikely(rv < 0)) {
         dbg_puts("knote_copyout failed");


### PR DESCRIPTION
This patch is originally from @chrisjlly, who was investigating it as part of https://github.com/zeek/zeek/issues/4727. This resolves the crash reported in https://github.com/mheily/libkqueue/issues/155. It's unfortunately mostly a band-aid fix, since it doesn't resolve the reason why the filter index would end up invalid, but at least it keeps the code from crashing.

This also fixes the patch from https://github.com/mheily/libkqueue/commit/b26a202430b2e6083ab9d6548bea187344fab68a to set the generator passed to CMake to be Visual Studio 2022.