### PR TITLE
Fix Windows debug builds

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -29,6 +29,9 @@ jobs:
     timeout-minutes: 5
     runs-on: windows-2022
     name: CI-windows (build)
+    strategy:
+      matrix:
+        build_type: [Release, Debug]
 
     steps:
       - uses: actions/checkout@v2
@@ -36,8 +39,8 @@ jobs:
       - name: Configure build system
         run: |
           cmake --version
-          cmake -S . -B build_x64 -A x64 -G "Visual Studio 17 2022" -DSTATICLIB=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON
+          cmake -S . -B build_x64 -A x64 -G "Visual Studio 17 2022" -DSTATICLIB=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_VERBOSE_MAKEFILE=ON
 
       - name: Build libkqueue
         run: |
-          cmake --build build_x64 --target install --config Release --parallel 1
+          cmake --build build_x64 --target install --config ${{ matrix.build_type }} --parallel 1

--- a/src/common/debug.h
+++ b/src/common/debug.h
@@ -144,6 +144,14 @@ typedef struct {
     } \
 } while (0)
 
+#ifdef _WIN32
+# define tracing_mutex_unlock(x)  do { \
+    (x)->mtx_status = MTX_UNLOCKED; \
+    (x)->mtx_owner = -1; \
+    pthread_mutex_unlock(&((x)->mtx_lock)); \
+    dbg_printf("[%i]: unlocked %s", __LINE__, # x); \
+} while (0)
+#else
 # define tracing_mutex_unlock(x)  do { \
     (x)->mtx_status = MTX_UNLOCKED; \
     (x)->mtx_owner = -1; \
@@ -153,6 +161,7 @@ typedef struct {
     }; \
     dbg_printf("[%i]: unlocked %s", __LINE__, # x); \
 } while (0)
+#endif
 
 typedef void (*dbg_func_t)(char const *fmt, ...);
 


### PR DESCRIPTION
This reverts the change from e02fab64c534e54007b4f62fcac3d45a77c9ffb5 for Windows, opting to not check the return value of a function that returns void anyways. I could also see implementing `pthread_mutex_unlock` on Windows as a simple function that always returns zero, but reverting was the easier option. I also added a debug build to the Windows CI setup.